### PR TITLE
Add dark mode layout template

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,22 +4,29 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Developer Portfolio</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <header>
         <nav>
-            <ul>
+            <ul class="nav-links">
+                <li><a href="#home">Home</a></li>
                 <li><a href="#about">About</a></li>
                 <li><a href="#projects">Projects</a></li>
                 <li><a href="#blog">Blog</a></li>
                 <li><a href="#contact">Contact</a></li>
             </ul>
             <button id="theme-toggle" aria-label="Toggle dark mode">Toggle Theme</button>
+            <button id="menu-toggle" aria-label="Toggle navigation">Menu</button>
         </nav>
     </header>
 
     <main>
+        <section id="home" class="hero">
+            <h1>Brayden Diaz</h1>
+            <p>Building a better world, one line of code at a time.</p>
+        </section>
         <section id="about" class="about-me">
             <h2 class="display-name">Brayden Diaz</h2>
             <p class="intro">I'm Brayden, a curious young man committed to growth, learning, and creating. While I keep things goofy, my professionalism and care for others shine through. I love inspiring people to build amazing things.</p>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const toggle = document.getElementById('theme-toggle');
-    toggle.addEventListener('click', () => {
+    const themeToggle = document.getElementById('theme-toggle');
+    const menuToggle = document.getElementById('menu-toggle');
+    const navLinks = document.querySelector('.nav-links');
+
+    themeToggle.addEventListener('click', () => {
         document.body.classList.toggle('light-mode');
+    });
+
+    menuToggle.addEventListener('click', () => {
+        navLinks.classList.toggle('active');
     });
 });

--- a/style.css
+++ b/style.css
@@ -1,28 +1,44 @@
 :root {
-    --bg-color: #121212;
-    --text-color: #ffffff;
-    --accent-color: #1e90ff;
+    --bg-color: #0d1117;
+    --text-color: #e6e6e6;
+    --accent-color: #64ffda;
+    --font-body: 'Inter', Arial, sans-serif;
+    --font-heading: 'Poppins', sans-serif;
 }
 
 body {
     margin: 0;
     padding: 0;
-    font-family: Arial, sans-serif;
+    font-family: var(--font-body);
     background-color: var(--bg-color);
     color: var(--text-color);
+    line-height: 1.6;
+    transition: background-color 0.3s, color 0.3s;
+}
+
+h1, h2, h3, h4 {
+    font-family: var(--font-heading);
+    margin-bottom: 0.5rem;
+}
+
+header {
+    position: sticky;
+    top: 0;
+    background: var(--bg-color);
+    z-index: 10;
 }
 
 nav {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 1rem;
+    padding: 1rem 2rem;
 }
 
-nav ul {
+.nav-links {
     list-style: none;
     display: flex;
-    gap: 1rem;
+    gap: 1.5rem;
     margin: 0;
     padding: 0;
 }
@@ -30,15 +46,62 @@ nav ul {
 nav a {
     color: var(--text-color);
     text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+nav a:hover,
+nav a:focus {
+    color: var(--accent-color);
+}
+
+#theme-toggle,
+#menu-toggle {
+    background: none;
+    border: 1px solid var(--accent-color);
+    color: var(--accent-color);
+    padding: 0.4rem 0.8rem;
+    margin-left: 0.5rem;
+    cursor: pointer;
+    transition: background-color 0.3s, color 0.3s;
+}
+
+#theme-toggle:hover,
+#menu-toggle:hover {
+    background-color: var(--accent-color);
+    color: var(--bg-color);
+}
+
+#menu-toggle {
+    display: none;
 }
 
 section {
-    padding: 2rem 1rem;
+    padding: 3rem 1rem;
+}
+
+.hero {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 60vh;
+    text-align: center;
+}
+
+.hero p {
+    color: var(--accent-color);
+    font-weight: 700;
+}
+
+.about-me {
+    max-width: 700px;
+    margin: 0 auto;
+    text-align: center;
 }
 
 footer {
     text-align: center;
-    padding: 1rem;
+    padding: 2rem 0;
 }
 
 body.light-mode {
@@ -46,23 +109,28 @@ body.light-mode {
     --text-color: #000000;
 }
 
-.about-me {
-    max-width: 600px;
-    margin: 0 auto;
-    text-align: center;
-}
+@media (max-width: 600px) {
+    .nav-links {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        background: var(--bg-color);
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+        padding: 1rem 0;
+        border-top: 1px solid var(--accent-color);
+        transform: scaleY(0);
+        transform-origin: top;
+        transition: transform 0.3s ease-in-out;
+    }
 
-.about-me .display-name {
-    color: var(--accent-color);
-    margin-bottom: 0.5rem;
-}
+    .nav-links.active {
+        transform: scaleY(1);
+    }
 
-.about-me .intro {
-    line-height: 1.6;
-}
-
-.about-me .quote {
-    font-style: italic;
-    color: var(--accent-color);
-    margin-top: 1rem;
+    #menu-toggle {
+        display: inline-block;
+    }
 }


### PR DESCRIPTION
## Summary
- build a minimalist dark theme using CSS variables
- add hero section and responsive nav with toggle menu
- update fonts to Inter and Poppins
- add simple script for dark mode and menu toggle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fa1113dec8320a04100f42078db95