### PR TITLE
Add skills and tools section with interactive placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
             <ul class="nav-links">
                 <li><a href="#home">Home</a></li>
                 <li><a href="#about">About</a></li>
+                <li><a href="#skills">Skills</a></li>
                 <li><a href="#projects">Projects</a></li>
                 <li><a href="#blog">Blog</a></li>
                 <li><a href="#contact">Contact</a></li>
@@ -31,6 +32,47 @@
             <h2 class="display-name">Brayden Diaz</h2>
             <p class="intro">I'm Brayden, a curious young man committed to growth, learning, and creating. While I keep things goofy, my professionalism and care for others shine through. I love inspiring people to build amazing things.</p>
             <p class="quote">"Building a better world, one line of code at a time."</p>
+        </section>
+
+        <section id="skills" class="skills-section">
+            <h2>Skills &amp; Tools</h2>
+            <div class="skills-groups">
+                <div class="skill-group">
+                    <h3>Frontend</h3>
+                    <div class="skills-grid">
+                        <div class="skill-item" data-tooltip="React">React</div>
+                        <div class="skill-item" data-tooltip="JavaScript">JavaScript</div>
+                        <div class="skill-item" data-tooltip="HTML">HTML</div>
+                        <div class="skill-item" data-tooltip="CSS">CSS</div>
+                    </div>
+                </div>
+                <div class="skill-group">
+                    <h3>Backend</h3>
+                    <div class="skills-grid">
+                        <div class="skill-item" data-tooltip="SQL">SQL</div>
+                        <div class="skill-item" data-tooltip="Python">Python</div>
+                        <div class="skill-item" data-tooltip="Java">Java</div>
+                        <div class="skill-item" data-tooltip="C++">C++</div>
+                    </div>
+                </div>
+                <div class="skill-group">
+                    <h3>Tools</h3>
+                    <div class="skills-grid">
+                        <div class="skill-item" data-tooltip="Microsoft Office Suite">Microsoft Office</div>
+                        <div class="skill-item" data-tooltip="Google Suite">Google Suite</div>
+                    </div>
+                </div>
+                <div class="skill-group">
+                    <h3>Extra</h3>
+                    <div class="skills-grid">
+                        <div class="skill-item" data-tooltip="AI-assisted coding">AI-assisted coding</div>
+                    </div>
+                </div>
+            </div>
+
+            <div id="github-graph" class="github-graph">
+                <div class="graph-placeholder"></div>
+            </div>
         </section>
 
         <section id="projects">

--- a/script.js
+++ b/script.js
@@ -2,6 +2,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const themeToggle = document.getElementById('theme-toggle');
     const menuToggle = document.getElementById('menu-toggle');
     const navLinks = document.querySelector('.nav-links');
+    const skillItems = document.querySelectorAll('.skill-item');
+    const graphPlaceholder = document.querySelector('.graph-placeholder');
 
     themeToggle.addEventListener('click', () => {
         document.body.classList.toggle('light-mode');
@@ -10,4 +12,32 @@ document.addEventListener('DOMContentLoaded', () => {
     menuToggle.addEventListener('click', () => {
         navLinks.classList.toggle('active');
     });
+
+    // simple tooltip functionality
+    skillItems.forEach(item => {
+        item.addEventListener('mouseenter', () => {
+            const tooltip = document.createElement('div');
+            tooltip.className = 'tooltip';
+            tooltip.textContent = item.dataset.tooltip;
+            document.body.appendChild(tooltip);
+            const rect = item.getBoundingClientRect();
+            const tipRect = tooltip.getBoundingClientRect();
+            tooltip.style.left = `${rect.left + rect.width / 2 - tipRect.width / 2}px`;
+            tooltip.style.top = `${rect.top - tipRect.height - 8 + window.scrollY}px`;
+            item._tooltip = tooltip;
+        });
+        item.addEventListener('mouseleave', () => {
+            if (item._tooltip) {
+                item._tooltip.remove();
+                item._tooltip = null;
+            }
+        });
+    });
+
+    // generate placeholder squares for GitHub graph
+    if (graphPlaceholder) {
+        for (let i = 0; i < 120; i++) {
+            graphPlaceholder.appendChild(document.createElement('div'));
+        }
+    }
 });

--- a/style.css
+++ b/style.css
@@ -134,3 +134,76 @@ body.light-mode {
         display: inline-block;
     }
 }
+
+/* Skills section */
+.skills-section {
+    max-width: 900px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.skills-groups {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    justify-content: center;
+}
+
+.skill-group {
+    flex: 1 1 200px;
+}
+
+.skills-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    gap: 0.5rem;
+}
+
+.skill-item {
+    background-color: #1f1f1f;
+    padding: 0.75rem;
+    border-radius: 4px;
+    transition: transform 0.2s, background-color 0.2s;
+    cursor: pointer;
+    position: relative;
+}
+
+.skill-item:hover {
+    background-color: var(--accent-color);
+    transform: translateY(-3px);
+    color: var(--bg-color);
+}
+
+.tooltip {
+    position: absolute;
+    background: var(--accent-color);
+    color: var(--bg-color);
+    padding: 0.3rem 0.6rem;
+    border-radius: 3px;
+    font-size: 0.75rem;
+    pointer-events: none;
+    z-index: 100;
+}
+
+.github-graph {
+    margin-top: 2rem;
+}
+
+.graph-placeholder {
+    display: grid;
+    grid-template-columns: repeat(20, 12px);
+    gap: 2px;
+    justify-content: center;
+}
+
+.graph-placeholder div {
+    width: 12px;
+    height: 12px;
+    background-color: #30363d;
+    animation: pulse 1.5s infinite ease-in-out;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 1; }
+}


### PR DESCRIPTION
## Summary
- add new navigation link to skills section
- implement a Skills & Tools section grouped by type
- style skill cards and animated contribution graph placeholder
- add tooltip and graph square generation logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fa2056c388320857f5157f7e6fea4