### PR TITLE
Add basic blog section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Portfolio
+
+This repository contains the source for my developer portfolio. The `/blog` folder hosts a simple blog section written with HTML, CSS and JavaScript. Blog posts are stored under `/blog/posts` and listed in `posts.json` for easy addition of new articles.

--- a/blog/blog.js
+++ b/blog/blog.js
@@ -1,0 +1,69 @@
+async function loadPosts() {
+  const response = await fetch('posts.json');
+  const posts = await response.json();
+  return posts;
+}
+
+function createPostPreview(post) {
+  const article = document.createElement('article');
+  article.className = 'post-preview';
+  article.dataset.tags = post.tags.join(' ');
+
+  const titleLink = document.createElement('a');
+  titleLink.href = post.file;
+  titleLink.textContent = post.title;
+  const title = document.createElement('h2');
+  title.appendChild(titleLink);
+
+  const date = document.createElement('p');
+  date.className = 'date';
+  date.textContent = post.date;
+
+  const excerpt = document.createElement('p');
+  excerpt.textContent = post.excerpt;
+
+  const tags = document.createElement('p');
+  tags.className = 'tags';
+  tags.textContent = post.tags.map(t => `#${t}`).join(' ');
+
+  const linkedinBtn = document.createElement('button');
+  linkedinBtn.className = 'linkedin-btn';
+  linkedinBtn.textContent = 'Share on LinkedIn';
+  linkedinBtn.addEventListener('click', () => alert('LinkedIn cross-post coming soon!'));
+
+  article.appendChild(title);
+  article.appendChild(date);
+  article.appendChild(excerpt);
+  article.appendChild(tags);
+  article.appendChild(linkedinBtn);
+  return article;
+}
+
+function displayPosts(posts) {
+  const container = document.getElementById('posts');
+  container.innerHTML = '';
+  posts.forEach(p => container.appendChild(createPostPreview(p)));
+}
+
+function setupTagFilter(posts) {
+  const buttons = document.querySelectorAll('.tag-filter button');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      buttons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      const tag = btn.dataset.tag;
+      if (tag === 'All') {
+        displayPosts(posts);
+      } else {
+        const filtered = posts.filter(p => p.tags.includes(tag));
+        displayPosts(filtered);
+      }
+    });
+  });
+}
+
+window.addEventListener('DOMContentLoaded', async () => {
+  const posts = await loadPosts();
+  displayPosts(posts);
+  setupTagFilter(posts);
+});

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="header">
+    <h1>Blog</h1>
+    <a class="rss" href="#">RSS Feed (coming soon)</a>
+  </header>
+  <div class="tag-filter">
+    <button data-tag="All" class="active">All</button>
+    <button data-tag="Tech">#Tech</button>
+    <button data-tag="Growth">#Growth</button>
+    <button data-tag="Personal">#Personal</button>
+    <button data-tag="AI">#AI</button>
+  </div>
+  <div id="posts"></div>
+
+  <script src="blog.js"></script>
+</body>
+</html>

--- a/blog/posts.json
+++ b/blog/posts.json
@@ -1,0 +1,16 @@
+[
+  {
+    "title": "Welcome to My Blog",
+    "date": "2025-06-01",
+    "excerpt": "Kicking off my new developer blog with some thoughts about building projects and sharing progress.",
+    "tags": ["Tech", "Personal"],
+    "file": "posts/welcome.html"
+  },
+  {
+    "title": "The Future of AI",
+    "date": "2025-06-02",
+    "excerpt": "A quick look into how AI is shaping modern development and what excites me about it.",
+    "tags": ["Tech", "AI"],
+    "file": "posts/ai-future.html"
+  }
+]

--- a/blog/posts/ai-future.html
+++ b/blog/posts/ai-future.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../style.css">
+  <title>The Future of AI</title>
+</head>
+<body>
+  <article class="post">
+    <h1>The Future of AI</h1>
+    <p class="date">June 2, 2025</p>
+    <p>Artificial intelligence continues to transform how we build applications. I'm fascinated by the possibilities it opens up for developers.</p>
+    <p class="tags">#Tech #AI</p>
+    <button class="linkedin-btn" onclick="alert('LinkedIn cross-post coming soon!')">Share on LinkedIn</button>
+  </article>
+  <a href="../index.html" class="back">Back to blog</a>
+</body>
+</html>

--- a/blog/posts/welcome.html
+++ b/blog/posts/welcome.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../style.css">
+  <title>Welcome to My Blog</title>
+</head>
+<body>
+  <article class="post">
+    <h1>Welcome to My Blog</h1>
+    <p class="date">June 1, 2025</p>
+    <p>Hi there! I'm excited to share updates on my projects, things I learn, and thoughts about tech. Stay tuned for more posts!</p>
+    <p class="tags">#Tech #Personal</p>
+    <button class="linkedin-btn" onclick="alert('LinkedIn cross-post coming soon!')">Share on LinkedIn</button>
+  </article>
+  <a href="../index.html" class="back">Back to blog</a>
+</body>
+</html>

--- a/blog/style.css
+++ b/blog/style.css
@@ -1,0 +1,66 @@
+body {
+  background-color: #121212;
+  color: #eee;
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 0 1rem;
+}
+
+h1, h2, h3 { color: #fff; }
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+}
+
+.tag-filter button {
+  margin-right: 0.5rem;
+  padding: 0.3rem 0.6rem;
+  background-color: #333;
+  color: #eee;
+  border: 1px solid #555;
+  cursor: pointer;
+}
+
+.tag-filter button.active {
+  background-color: #555;
+}
+
+.post-preview {
+  border-bottom: 1px solid #333;
+  padding: 1rem 0;
+}
+
+.post-preview a {
+  color: #78a9ff;
+  text-decoration: none;
+}
+
+.post-preview a:hover {
+  text-decoration: underline;
+}
+
+.tags {
+  color: #bdbdbd;
+}
+
+.linkedin-btn {
+  background-color: #0a66c2;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+.back {
+  display: inline-block;
+  margin-top: 2rem;
+  color: #78a9ff;
+}
+
+.rss {
+  color: #78a9ff;
+}


### PR DESCRIPTION
## Summary
- build `/blog` directory for static blog content
- add sample posts with LinkedIn placeholder buttons
- implement tag filter logic and dark theme styling

## Testing
- `ls -R | head`

------
https://chatgpt.com/codex/tasks/task_e_683fa3bc6e1c8320ba7e5a03ddc8488a