### PR TITLE
Add Vision section with timeline

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -14,6 +14,7 @@
             <ul class="nav-links">
                 <li><a href="../index.html#home">Home</a></li>
                 <li><a href="../index.html#projects">Projects</a></li>
+                <li><a href="../index.html#vision">Vision</a></li>
                 <li><a href="../index.html#blog">Blog</a></li>
                 <li><a href="../index.html#contact">Contact</a></li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
                 <li><a href="#about">About</a></li>
                 <li><a href="#skills">Skills</a></li>
                 <li><a href="#projects">Projects</a></li>
+                <li><a href="#vision">Vision</a></li>
                 <li><a href="#blog">Blog</a></li>
                 <li><a href="#contact">Contact</a></li>
             </ul>
@@ -171,6 +172,32 @@
         <section id="blog">
             <h2>Blog</h2>
             <p>Blog section placeholder.</p>
+        </section>
+
+        <section id="vision" class="vision-section">
+            <h2>Mission &amp; Vision</h2>
+            <p><strong>Short term:</strong> showcase my work, tackle freelance projects, and build meaningful connections.</p>
+            <p><strong>Long term:</strong> grow into an entrepreneur and, one day, share knowledge as a professor.</p>
+            <h3>Timeline</h3>
+            <div class="timeline vision-timeline">
+                <div class="timeline-item">
+                    <h4>Q1&nbsp;2024</h4>
+                    <p>Initial portfolio launch.</p>
+                </div>
+                <div class="timeline-item">
+                    <h4>Q2&nbsp;2024</h4>
+                    <p>Blog and networking features.</p>
+                </div>
+                <div class="timeline-item">
+                    <h4>Q3&nbsp;2024</h4>
+                    <p>Showcase freelance projects.</p>
+                </div>
+                <div class="timeline-item">
+                    <h4>Q4&nbsp;2024</h4>
+                    <p>Launch mentorship content.</p>
+                </div>
+            </div>
+            <a href="#blog" class="subscribe-btn">Follow for Updates</a>
         </section>
 
         <section id="contact" class="contact-section">

--- a/style.css
+++ b/style.css
@@ -370,6 +370,34 @@ body.light-mode {
     border-radius: 4px;
 }
 
+/* Vision Section */
+.vision-section {
+    max-width: 900px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.vision-section strong {
+    color: var(--accent-color);
+}
+
+.subscribe-btn {
+    display: inline-block;
+    margin-top: 1rem;
+    padding: 0.6rem 1.2rem;
+    background: none;
+    border: 1px solid var(--accent-color);
+    color: var(--accent-color);
+    text-decoration: none;
+    border-radius: 4px;
+    transition: background-color 0.3s, color 0.3s;
+}
+
+.subscribe-btn:hover {
+    background: var(--accent-color);
+    color: var(--bg-color);
+}
+
 .testimonials {
     margin-top: 2rem;
     display: flex;


### PR DESCRIPTION
## Summary
- add "Vision" link to navigation
- provide a Mission & Vision section with short‑ and long‑term goals
- show site update timeline and follow button
- style new section within dark theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fa6cc24b883209fcd42e834535d28